### PR TITLE
nginx reverse proxy

### DIFF
--- a/boyar/boyar.go
+++ b/boyar/boyar.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/orbs-network/boyarin/config"
 	"github.com/orbs-network/boyarin/strelets"
+	"github.com/orbs-network/boyarin/test"
 )
 
 type nodeConfiguration struct {
@@ -19,6 +20,7 @@ type NodeConfiguration interface {
 
 type Boyar interface {
 	ProvisionVirtualChains(ctx context.Context) error
+	ProvisionHttpAPIEndpoint(ctx context.Context) error
 }
 
 type boyar struct {
@@ -49,4 +51,9 @@ func (b *boyar) ProvisionVirtualChains(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (b *boyar) ProvisionHttpAPIEndpoint(ctx context.Context) error {
+	// TODO is there a better way to get a loopback interface?
+	return b.strelets.UpdateReverseProxy(ctx, b.config.Chains(), test.LocalIP())
 }

--- a/boyar/main/main.go
+++ b/boyar/main/main.go
@@ -43,4 +43,8 @@ func main() {
 	if err := b.ProvisionVirtualChains(context.Background()); err != nil {
 		panic(err)
 	}
+
+	if err := b.ProvisionHttpAPIEndpoint(context.Background()); err != nil {
+		panic(err)
+	}
 }

--- a/boyar/main/main.go
+++ b/boyar/main/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	switch *orchestratorPtr {
 	case "docker":
-		orchestrator, err = adapter.NewDockerAPI()
+		orchestrator, err = adapter.NewDockerAPI("_tmp")
 	case "swarm":
 		orchestrator, err = adapter.NewDockerSwarm()
 	default:

--- a/boyar/test/harness.go
+++ b/boyar/test/harness.go
@@ -24,3 +24,8 @@ func (s *streletsMock) RemoveVirtualChain(ctx context.Context, input *strelets.R
 func (s *streletsMock) VerifyMocks(t *testing.T) {
 	s.mock.AssertExpectations(t)
 }
+
+func (s *streletsMock) UpdateReverseProxy(ctx context.Context, chains []*strelets.VirtualChain, ip string) error {
+	s.mock.MethodCalled("UpdateReverseProxy", chains, ip)
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	}
 
 	ctx := context.Background()
-	docker, err := adapter.NewDockerAPI()
+	docker, err := adapter.NewDockerAPI(root)
 	if err != nil {
 		panic(err)
 	}

--- a/strelets/adapter/docker.go
+++ b/strelets/adapter/docker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/runconfig"
+	"path/filepath"
 )
 
 type dockerRunner struct {
@@ -17,14 +18,22 @@ type dockerRunner struct {
 	config        map[string]interface{}
 }
 
-func NewDockerAPI() (Orchestrator, error) {
+func NewDockerAPI(root string) (Orchestrator, error) {
 	client, err := client.NewClientWithOpts(client.WithVersion(DOCKER_API_VERSION))
 
 	if err != nil {
 		return nil, err
 	}
 
-	return &dockerAPI{client: client}, nil
+	absoluteRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dockerAPI{
+		client: client,
+		root:   absoluteRoot,
+	}, nil
 }
 
 func (d *dockerAPI) PullImage(ctx context.Context, imageName string) error {

--- a/strelets/adapter/docker_prepare.go
+++ b/strelets/adapter/docker_prepare.go
@@ -5,13 +5,13 @@ import (
 	"strconv"
 )
 
-func (d *dockerAPI) Prepare(ctx context.Context, imageName string, containerName string, root string, httpPort int, gossipPort int, appConfig *AppConfig) (Runner, error) {
-	if err := storeConfiguration(containerName, root, appConfig); err != nil {
+func (d *dockerAPI) Prepare(ctx context.Context, imageName string, containerName string, httpPort int, gossipPort int, appConfig *AppConfig) (Runner, error) {
+	if err := storeVirtualChainConfiguration(containerName, d.root, appConfig); err != nil {
 		return nil, err
 	}
 
 	exposedPorts, portBindings := buildDockerNetworkOptions(httpPort, gossipPort)
-	config := buildDockerConfig(imageName, exposedPorts, portBindings, getDockerContainerVolumes(containerName, root))
+	config := buildDockerConfig(imageName, exposedPorts, portBindings, getVirtualChainDockerContainerVolumes(containerName, d.root))
 
 	return &dockerRunner{
 		client:        d.client,

--- a/strelets/adapter/docker_prepare.go
+++ b/strelets/adapter/docker_prepare.go
@@ -11,7 +11,7 @@ func (d *dockerAPI) Prepare(ctx context.Context, imageName string, containerName
 	}
 
 	exposedPorts, portBindings := buildDockerNetworkOptions(httpPort, gossipPort)
-	config := buildDockerConfig(imageName, exposedPorts, portBindings, getVirtualChainDockerContainerVolumes(containerName, d.root))
+	config := getVirtualChainContainerConfig(imageName, exposedPorts, portBindings, getVirtualChainDockerContainerVolumes(containerName, d.root))
 
 	return &dockerRunner{
 		client:        d.client,
@@ -32,7 +32,7 @@ func buildDockerNetworkOptions(httpPort int, gossipPort int) (exposedPorts map[s
 	return
 }
 
-func buildDockerConfig(
+func getVirtualChainContainerConfig(
 	imageName string,
 	exposedPorts map[string]interface{},
 	portBindings map[string][]dockerPortBinding,

--- a/strelets/adapter/docker_prepare_reverse_proxy.go
+++ b/strelets/adapter/docker_prepare_reverse_proxy.go
@@ -17,6 +17,14 @@ func (d *dockerAPI) PrepareReverseProxy(ctx context.Context, config string) (Run
 		return nil, err
 	}
 
+	return &dockerRunner{
+		client:        d.client,
+		config:        getNginxContainerConfig(image, nginxConfigDir),
+		containerName: PROXY_CONTAINER_NAME,
+	}, nil
+}
+
+func getNginxContainerConfig(image string, nginxConfigDir string) map[string]interface{} {
 	configMap := make(map[string]interface{})
 	configMap["Image"] = image
 
@@ -36,9 +44,5 @@ func (d *dockerAPI) PrepareReverseProxy(ctx context.Context, config string) (Run
 
 	configMap["HostConfig"] = hostConfigMap
 
-	return &dockerRunner{
-		client:        d.client,
-		config:        configMap,
-		containerName: PROXY_CONTAINER_NAME,
-	}, nil
+	return configMap
 }

--- a/strelets/adapter/docker_prepare_reverse_proxy.go
+++ b/strelets/adapter/docker_prepare_reverse_proxy.go
@@ -39,6 +39,6 @@ func (d *dockerAPI) PrepareReverseProxy(ctx context.Context, config string) (Run
 	return &dockerRunner{
 		client:        d.client,
 		config:        configMap,
-		containerName: "http-api-reverse-proxy",
+		containerName: PROXY_CONTAINER_NAME,
 	}, nil
 }

--- a/strelets/adapter/docker_prepare_reverse_proxy_test.go
+++ b/strelets/adapter/docker_prepare_reverse_proxy_test.go
@@ -1,0 +1,15 @@
+package adapter
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_getNginxContainerConfig(t *testing.T) {
+	config := getNginxContainerConfig("nginx:1.13.1", "/tmp/config")
+	result, _ := json.Marshal(config)
+
+	expectedConfig := `{"ExposedPorts":{"80/tcp":{}},"HostConfig":{"Binds":["/tmp/config:/etc/nginx/conf.d"],"PortBindings":{"80/tcp":[{"HostIp":"0.0.0.0","HostPort":"80"}]}},"Image":"nginx:1.13.1"}`
+	require.JSONEq(t, expectedConfig, string(result))
+}

--- a/strelets/adapter/docker_prepare_test.go
+++ b/strelets/adapter/docker_prepare_test.go
@@ -16,7 +16,7 @@ func Test_getDockerVolumes(t *testing.T) {
 	require.EqualValues(t, "/tmp/node1-chain-42/config/network.json", volumes.networkConfigFile)
 }
 
-const expectedDockerConfig = `{
+const expectedVirtualChainContainerConfig = `{
    "CMD":[
       "/opt/orbs/orbs-node",
       "--silent",
@@ -50,7 +50,7 @@ const expectedDockerConfig = `{
    "Image":"orbs:export"
 }`
 
-func Test_buildDockerConfig(t *testing.T) {
+func Test_getVirtualChainContainerConfig(t *testing.T) {
 	exposedPorts := make(map[string]interface{})
 	exposedPorts["8080/tcp"] = struct{}{}
 
@@ -64,8 +64,8 @@ func Test_buildDockerConfig(t *testing.T) {
 		logsDir:           "/tmp/root/v1/logs",
 	}
 
-	cfg := buildDockerConfig("orbs:export", exposedPorts, portBindings, volumes)
+	cfg := getVirtualChainContainerConfig("orbs:export", exposedPorts, portBindings, volumes)
 	jsonConfig, _ := json.Marshal(cfg)
 
-	require.JSONEq(t, expectedDockerConfig, string(jsonConfig), "expected config does not match generated config")
+	require.JSONEq(t, expectedVirtualChainContainerConfig, string(jsonConfig), "expected config does not match generated config")
 }

--- a/strelets/adapter/docker_prepare_test.go
+++ b/strelets/adapter/docker_prepare_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Test_getDockerVolumes(t *testing.T) {
-	volumes := getDockerContainerVolumes("node1-chain-42", "/tmp")
+	volumes := getVirtualChainDockerContainerVolumes("node1-chain-42", "/tmp")
 
 	require.NotNil(t, volumes)
 	require.EqualValues(t, "/tmp/node1-chain-42/config", volumes.configRootDir)

--- a/strelets/adapter/docker_store_configuration.go
+++ b/strelets/adapter/docker_store_configuration.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 )
 
@@ -48,4 +49,14 @@ func getVirtualChainDockerContainerVolumes(containerName string, root string) *v
 		keyPairConfigFile: filepath.Join(absolutePathToConfigDir, "keys.json"),
 		networkConfigFile: filepath.Join(absolutePathToConfigDir, "network.json"),
 	}
+}
+
+func storeNginxConfiguration(nginxConfigDir string, config string) error {
+	os.MkdirAll(nginxConfigDir, 0755)
+
+	if err := ioutil.WriteFile(path.Join(nginxConfigDir, "nginx.conf"), []byte(config), 0644); err != nil {
+		return fmt.Errorf("could not save nginx configuration: %s", err)
+	}
+
+	return nil
 }

--- a/strelets/adapter/docker_store_configuration.go
+++ b/strelets/adapter/docker_store_configuration.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 )
 
-func storeConfiguration(containerName string, containerRoot string, config *AppConfig) error {
-	vchainVolumes := getDockerContainerVolumes(containerName, containerRoot)
+func storeVirtualChainConfiguration(containerName string, containerRoot string, config *AppConfig) error {
+	vchainVolumes := getVirtualChainDockerContainerVolumes(containerName, containerRoot)
 	vchainVolumes.createDirs()
 
 	if err := ioutil.WriteFile(vchainVolumes.keyPairConfigFile, config.KeyPair, 0644); err != nil {
@@ -39,17 +39,13 @@ func createDir(path string) error {
 	return os.MkdirAll(path, 0755)
 }
 
-func getDockerContainerVolumes(containerName string, root string) *virtualChainVolumes {
+func getVirtualChainDockerContainerVolumes(containerName string, root string) *virtualChainVolumes {
 	absolutePathToConfigDir := filepath.Join(root, containerName, "config")
-	absolutePathToLogDir, _ := filepath.Abs(filepath.Join(root, containerName, "logs"))
-
-	absolutePathToNetworkConfig, _ := filepath.Abs(filepath.Join(absolutePathToConfigDir, "network.json"))
-	absolutePathToKeyPairConfig, _ := filepath.Abs(filepath.Join(absolutePathToConfigDir, "keys.json"))
 
 	return &virtualChainVolumes{
 		configRootDir:     absolutePathToConfigDir,
-		logsDir:           absolutePathToLogDir,
-		keyPairConfigFile: absolutePathToKeyPairConfig,
-		networkConfigFile: absolutePathToNetworkConfig,
+		logsDir:           filepath.Join(root, containerName, "logs"),
+		keyPairConfigFile: filepath.Join(absolutePathToConfigDir, "keys.json"),
+		networkConfigFile: filepath.Join(absolutePathToConfigDir, "network.json"),
 	}
 }

--- a/strelets/adapter/docker_store_configuration_test.go
+++ b/strelets/adapter/docker_store_configuration_test.go
@@ -13,13 +13,13 @@ func TestDockerAPI_StoreConfiguration(t *testing.T) {
 
 	require.NoError(t, err)
 
-	err = storeConfiguration("fake-container-name", dir, &AppConfig{
+	err = storeVirtualChainConfiguration("fake-container-name", dir, &AppConfig{
 		KeyPair: []byte("some-keys"),
 		Network: []byte("some-network-config"),
 	})
 	require.NoError(t, err)
 
-	volumes := getDockerContainerVolumes("fake-container-name", dir)
+	volumes := getVirtualChainDockerContainerVolumes("fake-container-name", dir)
 
 	require.DirExists(t, volumes.configRootDir)
 	require.DirExists(t, volumes.logsDir)

--- a/strelets/adapter/docker_update_reverse_proxy.go
+++ b/strelets/adapter/docker_update_reverse_proxy.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"path/filepath"
 )
 
 func (d *dockerAPI) UpdateReverseProxy(ctx context.Context, config string) error {
@@ -15,15 +14,12 @@ func (d *dockerAPI) UpdateReverseProxy(ctx context.Context, config string) error
 		return fmt.Errorf("could not pull latest nginx image: %s", err)
 	}
 
-	nginxConfigDir, err := filepath.Abs("_tmp/reverse-proxy")
-	if err != nil {
-		panic(err)
-	}
+	nginxConfigDir := path.Join(d.root, "reverse-proxy")
 
 	os.MkdirAll(nginxConfigDir, 0755)
 
 	if err := ioutil.WriteFile(path.Join(nginxConfigDir, "nginx.conf"), []byte(config), 0644); err != nil {
-		return fmt.Errorf("could not save nginx configuration", err)
+		return fmt.Errorf("could not save nginx configuration: %s", err)
 	}
 
 	configMap := make(map[string]interface{})

--- a/strelets/adapter/docker_update_reverse_proxy.go
+++ b/strelets/adapter/docker_update_reverse_proxy.go
@@ -1,0 +1,55 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+func (d *dockerAPI) UpdateReverseProxy(ctx context.Context, config string) error {
+	image := "nginx:latest"
+	if err := d.PullImage(ctx, image); err != nil {
+		return fmt.Errorf("could not pull latest nginx image: %s", err)
+	}
+
+	nginxConfigDir, err := filepath.Abs("_tmp/reverse-proxy")
+	if err != nil {
+		panic(err)
+	}
+
+	os.MkdirAll(nginxConfigDir, 0755)
+
+	if err := ioutil.WriteFile(path.Join(nginxConfigDir, "nginx.conf"), []byte(config), 0644); err != nil {
+		return fmt.Errorf("could not save nginx configuration", err)
+	}
+
+	configMap := make(map[string]interface{})
+	configMap["Image"] = image
+
+	exposedPorts := make(map[string]interface{})
+	exposedPorts["80/tcp"] = struct{}{}
+
+	configMap["ExposedPorts"] = exposedPorts
+
+	portBindings := make(map[string][]dockerPortBinding)
+	portBindings["80/tcp"] = []dockerPortBinding{{"0.0.0.0", "80"}}
+
+	hostConfigMap := make(map[string]interface{})
+	hostConfigMap["Binds"] = []string{
+		nginxConfigDir + ":/etc/nginx/conf.d",
+	}
+	hostConfigMap["PortBindings"] = portBindings
+
+	configMap["HostConfig"] = hostConfigMap
+
+	runner := &dockerRunner{
+		client:        d.client,
+		config:        configMap,
+		containerName: "http-api-reverse-proxy",
+	}
+
+	return runner.Run(ctx)
+}

--- a/strelets/adapter/orchestrator.go
+++ b/strelets/adapter/orchestrator.go
@@ -9,6 +9,7 @@ const DOCKER_API_VERSION = "1.38"
 
 type dockerAPI struct {
 	client *client.Client
+	root   string
 }
 
 type AppConfig struct {
@@ -22,7 +23,7 @@ type Runner interface {
 
 type Orchestrator interface {
 	PullImage(ctx context.Context, imageName string) error
-	Prepare(ctx context.Context, imageName string, containerName string, root string, httpPort int, gossipPort int, config *AppConfig) (Runner, error)
+	Prepare(ctx context.Context, imageName string, containerName string, httpPort int, gossipPort int, config *AppConfig) (Runner, error)
 	RemoveContainer(ctx context.Context, containerName string) error
 
 	UpdateReverseProxy(ctx context.Context, config string) error

--- a/strelets/adapter/orchestrator.go
+++ b/strelets/adapter/orchestrator.go
@@ -7,6 +7,8 @@ import (
 
 const DOCKER_API_VERSION = "1.38"
 
+const PROXY_CONTAINER_NAME = "http-api-reverse-proxy"
+
 type dockerAPI struct {
 	client *client.Client
 	root   string

--- a/strelets/adapter/orchestrator.go
+++ b/strelets/adapter/orchestrator.go
@@ -26,5 +26,5 @@ type Orchestrator interface {
 	Prepare(ctx context.Context, imageName string, containerName string, httpPort int, gossipPort int, config *AppConfig) (Runner, error)
 	RemoveContainer(ctx context.Context, containerName string) error
 
-	UpdateReverseProxy(ctx context.Context, config string) error
+	PrepareReverseProxy(ctx context.Context, config string) (Runner, error)
 }

--- a/strelets/adapter/orchestrator.go
+++ b/strelets/adapter/orchestrator.go
@@ -24,4 +24,6 @@ type Orchestrator interface {
 	PullImage(ctx context.Context, imageName string) error
 	Prepare(ctx context.Context, imageName string, containerName string, root string, httpPort int, gossipPort int, config *AppConfig) (Runner, error)
 	RemoveContainer(ctx context.Context, containerName string) error
+
+	UpdateReverseProxy(ctx context.Context, config string) error
 }

--- a/strelets/adapter/swarm.go
+++ b/strelets/adapter/swarm.go
@@ -54,3 +54,8 @@ func (d *dockerSwarm) RemoveContainer(ctx context.Context, containerName string)
 func getServiceId(input string) string {
 	return "stack-" + input
 }
+
+func (d *dockerSwarm) UpdateReverseProxy(ctx context.Context, config string) error {
+	panic("not implemented")
+	return nil
+}

--- a/strelets/adapter/swarm.go
+++ b/strelets/adapter/swarm.go
@@ -59,38 +59,3 @@ func (d *dockerSwarm) RemoveContainer(ctx context.Context, containerName string)
 func getServiceId(input string) string {
 	return "stack-" + input
 }
-
-func (d *dockerSwarm) PrepareReverseProxy(ctx context.Context, config string) (Runner, error) {
-	storedSecrets, err := d.storeNginxConfiguration(ctx, config)
-	if err != nil {
-		return nil, err
-	}
-
-	secrets := []*swarm.SecretReference{
-		{
-			SecretName: getSwarmSecretName(PROXY_CONTAINER_NAME, "nginx.conf"),
-			SecretID:   storedSecrets.nginxConfId,
-			File: &swarm.SecretReferenceFileTarget{
-				Name: "nginx.conf",
-				UID:  "0",
-				GID:  "0",
-			},
-		},
-		{
-			SecretName: getSwarmSecretName(PROXY_CONTAINER_NAME, "vchains.conf"),
-			SecretID:   storedSecrets.vchainConfId,
-			File: &swarm.SecretReferenceFileTarget{
-				Name: "vchains.conf",
-				UID:  "0",
-				GID:  "0",
-			},
-		},
-	}
-
-	spec := getNginxServiceSpec(secrets)
-
-	return &dockerSwarmRunner{
-		client: d.client,
-		spec:   spec,
-	}, nil
-}

--- a/strelets/adapter/swarm.go
+++ b/strelets/adapter/swarm.go
@@ -68,7 +68,7 @@ func (d *dockerSwarm) PrepareReverseProxy(ctx context.Context, config string) (R
 
 	secrets := []*swarm.SecretReference{
 		{
-			SecretName: getSwarmSecretName("http-api-reverse-proxy", "nginx.conf"),
+			SecretName: getSwarmSecretName(PROXY_CONTAINER_NAME, "nginx.conf"),
 			SecretID:   storedSecrets.nginxConfId,
 			File: &swarm.SecretReferenceFileTarget{
 				Name: "nginx.conf",
@@ -77,7 +77,7 @@ func (d *dockerSwarm) PrepareReverseProxy(ctx context.Context, config string) (R
 			},
 		},
 		{
-			SecretName: getSwarmSecretName("http-api-reverse-proxy", "vchains.conf"),
+			SecretName: getSwarmSecretName(PROXY_CONTAINER_NAME, "vchains.conf"),
 			SecretID:   storedSecrets.vchainConfId,
 			File: &swarm.SecretReferenceFileTarget{
 				Name: "vchains.conf",

--- a/strelets/adapter/swarm.go
+++ b/strelets/adapter/swarm.go
@@ -55,7 +55,7 @@ func getServiceId(input string) string {
 	return "stack-" + input
 }
 
-func (d *dockerSwarm) UpdateReverseProxy(ctx context.Context, config string) error {
+func (d *dockerSwarm) PrepareReverseProxy(ctx context.Context, config string) (Runner, error) {
 	panic("not implemented")
-	return nil
+	return nil, nil
 }

--- a/strelets/adapter/swarm_prepare.go
+++ b/strelets/adapter/swarm_prepare.go
@@ -101,37 +101,3 @@ func getVirtualChainServiceSpec(imageName string, containerName string, httpPort
 
 	return spec
 }
-
-func getNginxServiceSpec(secrets []*swarm.SecretReference) swarm.ServiceSpec {
-	restartDelay := time.Duration(10 * time.Second)
-	replicas := uint64(1)
-
-	spec := swarm.ServiceSpec{
-		TaskTemplate: swarm.TaskSpec{
-			ContainerSpec: &swarm.ContainerSpec{
-				Image:   "nginx:latest",
-				Secrets: secrets,
-				Command: []string{
-					"nginx", "-c", "/var/run/secrets/nginx.conf",
-				},
-			},
-			RestartPolicy: &swarm.RestartPolicy{
-				Delay: &restartDelay,
-			},
-		},
-		Mode: getServiceMode(replicas),
-		EndpointSpec: &swarm.EndpointSpec{
-			Ports: []swarm.PortConfig{
-				{
-					Protocol:      "tcp",
-					PublishMode:   swarm.PortConfigPublishModeIngress,
-					PublishedPort: uint32(80),
-					TargetPort:    80,
-				},
-			},
-		},
-	}
-	spec.Name = getServiceId(PROXY_CONTAINER_NAME)
-
-	return spec
-}

--- a/strelets/adapter/swarm_prepare.go
+++ b/strelets/adapter/swarm_prepare.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (d *dockerSwarm) Prepare(ctx context.Context, imageName string, containerName string, httpPort int, gossipPort int, appConfig *AppConfig) (Runner, error) {
-	config, err := d.storeConfiguration(ctx, containerName, appConfig)
+	config, err := d.storeVirtualChainConfiguration(ctx, containerName, appConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -17,7 +17,7 @@ func (d *dockerSwarm) Prepare(ctx context.Context, imageName string, containerNa
 		getSecretReference(containerName, config.networkSecretId, "network", "network.json"),
 	}
 
-	spec := getServiceSpec(imageName, containerName, httpPort, gossipPort, secrets)
+	spec := getVirtualChainServiceSpec(imageName, containerName, httpPort, gossipPort, secrets)
 
 	return &dockerSwarmRunner{
 		client: d.client,
@@ -83,7 +83,7 @@ func getEndpointsSpec(httpPort int, gossipPort int) *swarm.EndpointSpec {
 	}
 }
 
-func getServiceSpec(imageName string, containerName string, httpPort int, gossipPort int, secrets []*swarm.SecretReference) swarm.ServiceSpec {
+func getVirtualChainServiceSpec(imageName string, containerName string, httpPort int, gossipPort int, secrets []*swarm.SecretReference) swarm.ServiceSpec {
 	restartDelay := time.Duration(10 * time.Second)
 	replicas := uint64(1)
 
@@ -98,6 +98,40 @@ func getServiceSpec(imageName string, containerName string, httpPort int, gossip
 		EndpointSpec: getEndpointsSpec(httpPort, gossipPort),
 	}
 	spec.Name = getServiceId(containerName)
+
+	return spec
+}
+
+func getNginxServiceSpec(secrets []*swarm.SecretReference) swarm.ServiceSpec {
+	restartDelay := time.Duration(10 * time.Second)
+	replicas := uint64(1)
+
+	spec := swarm.ServiceSpec{
+		TaskTemplate: swarm.TaskSpec{
+			ContainerSpec: &swarm.ContainerSpec{
+				Image:   "nginx:latest",
+				Secrets: secrets,
+				Command: []string{
+					"nginx", "-c", "/var/run/secrets/nginx.conf",
+				},
+			},
+			RestartPolicy: &swarm.RestartPolicy{
+				Delay: &restartDelay,
+			},
+		},
+		Mode: getServiceMode(replicas),
+		EndpointSpec: &swarm.EndpointSpec{
+			Ports: []swarm.PortConfig{
+				{
+					Protocol:      "tcp",
+					PublishMode:   swarm.PortConfigPublishModeIngress,
+					PublishedPort: uint32(80),
+					TargetPort:    80,
+				},
+			},
+		},
+	}
+	spec.Name = getServiceId("http-api-reverse-proxy")
 
 	return spec
 }

--- a/strelets/adapter/swarm_prepare.go
+++ b/strelets/adapter/swarm_prepare.go
@@ -6,8 +6,8 @@ import (
 	"time"
 )
 
-func (d *dockerSwarm) Prepare(ctx context.Context, imageName string, containerName string, root string, httpPort int, gossipPort int, appConfig *AppConfig) (Runner, error) {
-	config, err := d.storeConfiguration(ctx, containerName, root, appConfig)
+func (d *dockerSwarm) Prepare(ctx context.Context, imageName string, containerName string, httpPort int, gossipPort int, appConfig *AppConfig) (Runner, error) {
+	config, err := d.storeConfiguration(ctx, containerName, appConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/strelets/adapter/swarm_prepare.go
+++ b/strelets/adapter/swarm_prepare.go
@@ -131,7 +131,7 @@ func getNginxServiceSpec(secrets []*swarm.SecretReference) swarm.ServiceSpec {
 			},
 		},
 	}
-	spec.Name = getServiceId("http-api-reverse-proxy")
+	spec.Name = getServiceId(PROXY_CONTAINER_NAME)
 
 	return spec
 }

--- a/strelets/adapter/swarm_prepare_reverse_proxy.go
+++ b/strelets/adapter/swarm_prepare_reverse_proxy.go
@@ -1,0 +1,58 @@
+package adapter
+
+import (
+	"context"
+	"github.com/docker/docker/api/types/swarm"
+	"time"
+)
+
+func (d *dockerSwarm) PrepareReverseProxy(ctx context.Context, config string) (Runner, error) {
+	storedSecrets, err := d.storeNginxConfiguration(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dockerSwarmRunner{
+		client: d.client,
+		spec:   getNginxServiceSpec(storedSecrets),
+	}, nil
+}
+
+func getNginxServiceSpec(storedSecrets *dockerSwarmNginxSecretsConfig) swarm.ServiceSpec {
+	restartDelay := time.Duration(10 * time.Second)
+	replicas := uint64(1)
+
+	secrets := []*swarm.SecretReference{
+		getSecretReference(PROXY_CONTAINER_NAME, storedSecrets.nginxConfId, "nginx.conf", "nginx.conf"),
+		getSecretReference(PROXY_CONTAINER_NAME, storedSecrets.vchainConfId, "vchains.conf", "vchains.conf"),
+	}
+
+	spec := swarm.ServiceSpec{
+		TaskTemplate: swarm.TaskSpec{
+			ContainerSpec: &swarm.ContainerSpec{
+				Image:   "nginx:latest",
+				Secrets: secrets,
+				Command: []string{
+					"nginx", "-c", "/var/run/secrets/nginx.conf",
+				},
+			},
+			RestartPolicy: &swarm.RestartPolicy{
+				Delay: &restartDelay,
+			},
+		},
+		Mode: getServiceMode(replicas),
+		EndpointSpec: &swarm.EndpointSpec{
+			Ports: []swarm.PortConfig{
+				{
+					Protocol:      "tcp",
+					PublishMode:   swarm.PortConfigPublishModeIngress,
+					PublishedPort: uint32(80),
+					TargetPort:    80,
+				},
+			},
+		},
+	}
+	spec.Name = getServiceId(PROXY_CONTAINER_NAME)
+
+	return spec
+}

--- a/strelets/adapter/swarm_prepare_reverse_proxy_test.go
+++ b/strelets/adapter/swarm_prepare_reverse_proxy_test.go
@@ -1,0 +1,72 @@
+package adapter
+
+import (
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func Test_getNginxServiceSpec(t *testing.T) {
+	restartDelay := time.Duration(10 * time.Second)
+	replicas := uint64(1)
+
+	secrets := &dockerSwarmNginxSecretsConfig{
+		vchainConfId: "vchain-config-id",
+		nginxConfId:  "nginx-config-id",
+	}
+	spec := getNginxServiceSpec(secrets)
+
+	require.EqualValues(t, spec.Name, "stack-"+PROXY_CONTAINER_NAME)
+
+	require.EqualValues(t, spec.TaskTemplate, swarm.TaskSpec{
+		ContainerSpec: &swarm.ContainerSpec{
+			Image: "nginx:latest",
+			Command: []string{
+				"nginx",
+				"-c", "/var/run/secrets/nginx.conf",
+			},
+			Secrets: []*swarm.SecretReference{
+				{
+					SecretName: getSwarmSecretName(PROXY_CONTAINER_NAME, "nginx.conf"),
+					SecretID:   "nginx-config-id",
+					File: &swarm.SecretReferenceFileTarget{
+						Name: "nginx.conf",
+						UID:  "0",
+						GID:  "0",
+					},
+				},
+				{
+					SecretName: getSwarmSecretName(PROXY_CONTAINER_NAME, "vchains.conf"),
+					SecretID:   "vchain-config-id",
+					File: &swarm.SecretReferenceFileTarget{
+						Name: "vchains.conf",
+						UID:  "0",
+						GID:  "0",
+					},
+				},
+			},
+		},
+		RestartPolicy: &swarm.RestartPolicy{
+			Condition: "",
+			Delay:     &restartDelay,
+		},
+	})
+
+	require.EqualValues(t, spec.EndpointSpec, &swarm.EndpointSpec{
+		Ports: []swarm.PortConfig{
+			{
+				Protocol:      "tcp",
+				PublishMode:   swarm.PortConfigPublishModeIngress,
+				PublishedPort: 80,
+				TargetPort:    80,
+			},
+		},
+	})
+
+	require.EqualValues(t, spec.Mode, swarm.ServiceMode{
+		Replicated: &swarm.ReplicatedService{
+			Replicas: &replicas,
+		},
+	})
+}

--- a/strelets/adapter/swarm_prepare_test.go
+++ b/strelets/adapter/swarm_prepare_test.go
@@ -16,7 +16,7 @@ func Test_getServiceSpec(t *testing.T) {
 	restartDelay := time.Duration(10 * time.Second)
 	replicas := uint64(1)
 
-	spec := getServiceSpec("orbs:export", containerName, 16160, 8800, secrets)
+	spec := getVirtualChainServiceSpec("orbs:export", containerName, 16160, 8800, secrets)
 
 	require.EqualValues(t, spec.Name, "stack-"+containerName)
 

--- a/strelets/adapter/swarm_prepare_test.go
+++ b/strelets/adapter/swarm_prepare_test.go
@@ -42,13 +42,13 @@ func Test_getServiceSpec(t *testing.T) {
 			{
 				Protocol:      "tcp",
 				PublishMode:   swarm.PortConfigPublishModeIngress,
-				PublishedPort: uint32(16160),
+				PublishedPort: 16160,
 				TargetPort:    8080,
 			},
 			{
 				Protocol:      "tcp",
 				PublishMode:   swarm.PortConfigPublishModeIngress,
-				PublishedPort: uint32(8800),
+				PublishedPort: 8800,
 				TargetPort:    4400,
 			},
 		},

--- a/strelets/adapter/swarm_store_configuration.go
+++ b/strelets/adapter/swarm_store_configuration.go
@@ -45,13 +45,13 @@ func getSwarmSecretName(containerName string, secretName string) string {
 func (d *dockerSwarm) storeNginxConfiguration(ctx context.Context, config string) (*dockerSwarmNginxSecretsConfig, error) {
 	secrets := &dockerSwarmNginxSecretsConfig{}
 
-	if nginxConfId, err := d.saveSwarmSecret(ctx, "http-api-reverse-proxy", "nginx.conf", []byte(DEFAULT_NGINX_CONFIG)); err != nil {
+	if nginxConfId, err := d.saveSwarmSecret(ctx, PROXY_CONTAINER_NAME, "nginx.conf", []byte(DEFAULT_NGINX_CONFIG)); err != nil {
 		return nil, fmt.Errorf("could not store nginx default config secret: %s", err)
 	} else {
 		secrets.nginxConfId = nginxConfId
 	}
 
-	if vchainConfId, err := d.saveSwarmSecret(ctx, "http-api-reverse-proxy", "vchains.conf", []byte(config)); err != nil {
+	if vchainConfId, err := d.saveSwarmSecret(ctx, PROXY_CONTAINER_NAME, "vchains.conf", []byte(config)); err != nil {
 		return nil, fmt.Errorf("could not store nginx vchains config secret: %s", err)
 	} else {
 		secrets.vchainConfId = vchainConfId

--- a/strelets/adapter/swarm_store_configuration.go
+++ b/strelets/adapter/swarm_store_configuration.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func (d *dockerSwarm) storeConfiguration(ctx context.Context, containerName string, root string, config *AppConfig) (*dockerSwarmSecretsConfig, error) {
+func (d *dockerSwarm) storeConfiguration(ctx context.Context, containerName string, config *AppConfig) (*dockerSwarmSecretsConfig, error) {
 	secrets := &dockerSwarmSecretsConfig{}
 
 	if keyPairSecretId, err := d.saveSwarmSecret(ctx, containerName, "keyPair", config.KeyPair); err != nil {

--- a/strelets/adapter/swarm_store_configuration.go
+++ b/strelets/adapter/swarm_store_configuration.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func (d *dockerSwarm) storeConfiguration(ctx context.Context, containerName string, config *AppConfig) (*dockerSwarmSecretsConfig, error) {
+func (d *dockerSwarm) storeVirtualChainConfiguration(ctx context.Context, containerName string, config *AppConfig) (*dockerSwarmSecretsConfig, error) {
 	secrets := &dockerSwarmSecretsConfig{}
 
 	if keyPairSecretId, err := d.saveSwarmSecret(ctx, containerName, "keyPair", config.KeyPair); err != nil {
@@ -41,3 +41,57 @@ func (d *dockerSwarm) saveSwarmSecret(ctx context.Context, containerName string,
 func getSwarmSecretName(containerName string, secretName string) string {
 	return strings.Join([]string{containerName, secretName}, "-")
 }
+
+func (d *dockerSwarm) storeNginxConfiguration(ctx context.Context, config string) (*dockerSwarmNginxSecretsConfig, error) {
+	secrets := &dockerSwarmNginxSecretsConfig{}
+
+	if nginxConfId, err := d.saveSwarmSecret(ctx, "http-api-reverse-proxy", "nginx.conf", []byte(DEFAULT_NGINX_CONFIG)); err != nil {
+		return nil, fmt.Errorf("could not store nginx default config secret: %s", err)
+	} else {
+		secrets.nginxConfId = nginxConfId
+	}
+
+	if vchainConfId, err := d.saveSwarmSecret(ctx, "http-api-reverse-proxy", "vchains.conf", []byte(config)); err != nil {
+		return nil, fmt.Errorf("could not store nginx vchains config secret: %s", err)
+	} else {
+		secrets.vchainConfId = vchainConfId
+	}
+
+	return secrets, nil
+}
+
+const DEFAULT_NGINX_CONFIG = `
+daemon off;
+
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /var/run/secrets/vchains.conf;
+}
+`

--- a/strelets/nginx_config.go
+++ b/strelets/nginx_config.go
@@ -9,7 +9,7 @@ func getNginxConfig(chains []*VirtualChain, ip string) string {
 	var locations []string
 
 	for _, chain := range chains {
-		locations = append(locations, fmt.Sprintf(`location /%d/ { proxy_pass http://%s:%d/; }`, chain.Id, ip, chain.HttpPort))
+		locations = append(locations, fmt.Sprintf(`location /vchains/%d/ { proxy_pass http://%s:%d/; }`, chain.Id, ip, chain.HttpPort))
 	}
 
 	return fmt.Sprintf(`server { listen 80; %s }`, strings.Join(locations, "\n"))

--- a/strelets/nginx_config.go
+++ b/strelets/nginx_config.go
@@ -1,0 +1,16 @@
+package strelets
+
+import (
+	"fmt"
+	"strings"
+)
+
+func getNginxConfig(chains []*VirtualChain, ip string) string {
+	var locations []string
+
+	for _, chain := range chains {
+		locations = append(locations, fmt.Sprintf(`location /%d/ { proxy_pass http://%s:%d/; }`, chain.Id, ip, chain.HttpPort))
+	}
+
+	return fmt.Sprintf(`server { listen 80; %s }`, strings.Join(locations, "\n"))
+}

--- a/strelets/nginx_config_test.go
+++ b/strelets/nginx_config_test.go
@@ -1,0 +1,17 @@
+package strelets
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_getNginxConfig(t *testing.T) {
+	chains := []*VirtualChain{
+		{
+			Id:       42,
+			HttpPort: 8081,
+		},
+	}
+
+	require.EqualValues(t, `server { listen 80; location /42/ { proxy_pass http://192.168.0.1:8081/; } }`, getNginxConfig(chains, "192.168.0.1"))
+}

--- a/strelets/nginx_config_test.go
+++ b/strelets/nginx_config_test.go
@@ -13,5 +13,5 @@ func Test_getNginxConfig(t *testing.T) {
 		},
 	}
 
-	require.EqualValues(t, `server { listen 80; location /42/ { proxy_pass http://192.168.0.1:8081/; } }`, getNginxConfig(chains, "192.168.0.1"))
+	require.EqualValues(t, `server { listen 80; location /vchains/42/ { proxy_pass http://192.168.0.1:8081/; } }`, getNginxConfig(chains, "192.168.0.1"))
 }

--- a/strelets/provision_virtual_chain.go
+++ b/strelets/provision_virtual_chain.go
@@ -36,7 +36,7 @@ func (s *strelets) ProvisionVirtualChain(ctx context.Context, input *ProvisionVi
 		return fmt.Errorf("could not read key pair config: %s at %s", err, input.KeyPairConfigPath)
 	}
 
-	if runner, err := s.orchestrator.Prepare(ctx, imageName, chain.getContainerName(), s.root, chain.HttpPort, chain.GossipPort, &adapter.AppConfig{
+	if runner, err := s.orchestrator.Prepare(ctx, imageName, chain.getContainerName(), chain.HttpPort, chain.GossipPort, &adapter.AppConfig{
 		KeyPair: keyPair,
 		Network: getNetworkConfigJSON(input.Peers),
 	}); err != nil {

--- a/strelets/strelets.go
+++ b/strelets/strelets.go
@@ -8,6 +8,7 @@ import (
 type Strelets interface {
 	ProvisionVirtualChain(ctx context.Context, input *ProvisionVirtualChainInput) error
 	RemoveVirtualChain(ctx context.Context, input *RemoveVirtualChainInput) error
+	UpdateReverseProxy(ctx context.Context, chains []*VirtualChain, ip string) error
 }
 
 type strelets struct {

--- a/strelets/update_reverse_proxy.go
+++ b/strelets/update_reverse_proxy.go
@@ -1,0 +1,7 @@
+package strelets
+
+import "context"
+
+func (s *strelets) UpdateReverseProxy(ctx context.Context, chains []*VirtualChain, ip string) error {
+	return s.orchestrator.UpdateReverseProxy(ctx, getNginxConfig(chains, ip))
+}

--- a/strelets/update_reverse_proxy.go
+++ b/strelets/update_reverse_proxy.go
@@ -3,5 +3,9 @@ package strelets
 import "context"
 
 func (s *strelets) UpdateReverseProxy(ctx context.Context, chains []*VirtualChain, ip string) error {
-	return s.orchestrator.UpdateReverseProxy(ctx, getNginxConfig(chains, ip))
+	if runner, err := s.orchestrator.PrepareReverseProxy(ctx, getNginxConfig(chains, ip)); err != nil {
+		return err
+	} else {
+		return runner.Run(ctx)
+	}
 }

--- a/test/e2e/e2e_reverse_proxy_test.go
+++ b/test/e2e/e2e_reverse_proxy_test.go
@@ -1,0 +1,53 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"github.com/orbs-network/boyarin/strelets"
+	"github.com/orbs-network/boyarin/strelets/adapter"
+	"github.com/orbs-network/boyarin/test"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestStrelets_UpdateReverseProxy(t *testing.T) {
+	server := test.CreateHttpServer("/test", func(writer http.ResponseWriter, request *http.Request) {
+		writer.Write([]byte("success"))
+	})
+	server.Start()
+	defer server.Shutdown()
+
+	api, err := adapter.NewDockerAPI()
+	require.NoError(t, err)
+
+	s := strelets.NewStrelets("_tmp", api)
+	chain := chain(1)
+	chain.HttpPort = server.Port()
+
+	chains := []*strelets.VirtualChain{chain}
+	ip := test.LocalIP()
+
+	err = s.UpdateReverseProxy(context.Background(), chains, ip)
+	require.NoError(t, err)
+	defer api.RemoveContainer(context.Background(), "http-api-reverse-proxy")
+
+	require.True(t, test.Eventually(20*time.Second, func() bool {
+		url := fmt.Sprintf("http://%s/%d/test", ip, chain.Id)
+		fmt.Println(url)
+		res, err := http.Get(url)
+		if err != nil {
+			return false
+		}
+		defer res.Body.Close()
+
+		body, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return false
+		}
+
+		return res.StatusCode == 200 && string(body) == "success"
+	}))
+}

--- a/test/e2e/e2e_reverse_proxy_test.go
+++ b/test/e2e/e2e_reverse_proxy_test.go
@@ -35,7 +35,7 @@ func testUpdateReverseProxy(t *testing.T, apiProvider func() (adapter.Orchestrat
 	defer api.RemoveContainer(context.Background(), "http-api-reverse-proxy")
 
 	require.True(t, test.Eventually(20*time.Second, func() bool {
-		url := fmt.Sprintf("http://%s/%d/test", ip, chain.Id)
+		url := fmt.Sprintf("http://%s/vchains/%d/test", ip, chain.Id)
 		fmt.Println(url)
 		res, err := http.Get(url)
 		if err != nil {

--- a/test/e2e/e2e_reverse_proxy_test.go
+++ b/test/e2e/e2e_reverse_proxy_test.go
@@ -13,16 +13,14 @@ import (
 	"time"
 )
 
-func Test_UpdateReverseProxyWithDocker(t *testing.T) {
-	skipUnlessDockerIsEnabled(t)
-
+func testUpdateReverseProxy(t *testing.T, apiProvider func() (adapter.Orchestrator, error)) {
 	server := test.CreateHttpServer("/test", func(writer http.ResponseWriter, request *http.Request) {
 		writer.Write([]byte("success"))
 	})
 	server.Start()
 	defer server.Shutdown()
 
-	api, err := adapter.NewDockerAPI("_tmp")
+	api, err := apiProvider()
 	require.NoError(t, err)
 
 	s := strelets.NewStrelets("_tmp", api)
@@ -54,43 +52,18 @@ func Test_UpdateReverseProxyWithDocker(t *testing.T) {
 	}))
 }
 
+func Test_UpdateReverseProxyWithDocker(t *testing.T) {
+	skipUnlessDockerIsEnabled(t)
+
+	testUpdateReverseProxy(t, func() (adapter.Orchestrator, error) {
+		return adapter.NewDockerAPI("_tmp")
+	})
+}
+
 func Test_UpdateReverseProxyWithSwarm(t *testing.T) {
 	skipUnlessSwarmIsEnabled(t)
 
-	server := test.CreateHttpServer("/test", func(writer http.ResponseWriter, request *http.Request) {
-		writer.Write([]byte("success"))
+	testUpdateReverseProxy(t, func() (adapter.Orchestrator, error) {
+		return adapter.NewDockerSwarm()
 	})
-	server.Start()
-	defer server.Shutdown()
-
-	api, err := adapter.NewDockerSwarm()
-	require.NoError(t, err)
-
-	s := strelets.NewStrelets("_tmp", api)
-	chain := chain(1)
-	chain.HttpPort = server.Port()
-
-	chains := []*strelets.VirtualChain{chain}
-	ip := test.LocalIP()
-
-	err = s.UpdateReverseProxy(context.Background(), chains, ip)
-	require.NoError(t, err)
-	defer api.RemoveContainer(context.Background(), "http-api-reverse-proxy")
-
-	require.True(t, test.Eventually(20*time.Second, func() bool {
-		url := fmt.Sprintf("http://%s/%d/test", ip, chain.Id)
-		fmt.Println(url)
-		res, err := http.Get(url)
-		if err != nil {
-			return false
-		}
-		defer res.Body.Close()
-
-		body, err := ioutil.ReadAll(res.Body)
-		if err != nil {
-			return false
-		}
-
-		return res.StatusCode == 200 && string(body) == "success"
-	}))
 }

--- a/test/e2e/e2e_reverse_proxy_test.go
+++ b/test/e2e/e2e_reverse_proxy_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-func TestStrelets_UpdateReverseProxy(t *testing.T) {
+func TestStrelets_UpdateReverseProxyOnDocker(t *testing.T) {
 	server := test.CreateHttpServer("/test", func(writer http.ResponseWriter, request *http.Request) {
 		writer.Write([]byte("success"))
 	})
@@ -21,6 +21,45 @@ func TestStrelets_UpdateReverseProxy(t *testing.T) {
 	defer server.Shutdown()
 
 	api, err := adapter.NewDockerAPI("_tmp")
+	require.NoError(t, err)
+
+	s := strelets.NewStrelets("_tmp", api)
+	chain := chain(1)
+	chain.HttpPort = server.Port()
+
+	chains := []*strelets.VirtualChain{chain}
+	ip := test.LocalIP()
+
+	err = s.UpdateReverseProxy(context.Background(), chains, ip)
+	require.NoError(t, err)
+	defer api.RemoveContainer(context.Background(), "http-api-reverse-proxy")
+
+	require.True(t, test.Eventually(20*time.Second, func() bool {
+		url := fmt.Sprintf("http://%s/%d/test", ip, chain.Id)
+		fmt.Println(url)
+		res, err := http.Get(url)
+		if err != nil {
+			return false
+		}
+		defer res.Body.Close()
+
+		body, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return false
+		}
+
+		return res.StatusCode == 200 && string(body) == "success"
+	}))
+}
+
+func TestStrelets_UpdateReverseProxyOnSwarm(t *testing.T) {
+	server := test.CreateHttpServer("/test", func(writer http.ResponseWriter, request *http.Request) {
+		writer.Write([]byte("success"))
+	})
+	server.Start()
+	defer server.Shutdown()
+
+	api, err := adapter.NewDockerSwarm()
 	require.NoError(t, err)
 
 	s := strelets.NewStrelets("_tmp", api)

--- a/test/e2e/e2e_reverse_proxy_test.go
+++ b/test/e2e/e2e_reverse_proxy_test.go
@@ -13,7 +13,9 @@ import (
 	"time"
 )
 
-func TestStrelets_UpdateReverseProxyOnDocker(t *testing.T) {
+func Test_UpdateReverseProxyWithDocker(t *testing.T) {
+	skipUnlessDockerIsEnabled(t)
+
 	server := test.CreateHttpServer("/test", func(writer http.ResponseWriter, request *http.Request) {
 		writer.Write([]byte("success"))
 	})
@@ -52,7 +54,9 @@ func TestStrelets_UpdateReverseProxyOnDocker(t *testing.T) {
 	}))
 }
 
-func TestStrelets_UpdateReverseProxyOnSwarm(t *testing.T) {
+func Test_UpdateReverseProxyWithSwarm(t *testing.T) {
+	skipUnlessSwarmIsEnabled(t)
+
 	server := test.CreateHttpServer("/test", func(writer http.ResponseWriter, request *http.Request) {
 		writer.Write([]byte("success"))
 	})

--- a/test/e2e/e2e_reverse_proxy_test.go
+++ b/test/e2e/e2e_reverse_proxy_test.go
@@ -20,7 +20,7 @@ func TestStrelets_UpdateReverseProxy(t *testing.T) {
 	server.Start()
 	defer server.Shutdown()
 
-	api, err := adapter.NewDockerAPI()
+	api, err := adapter.NewDockerAPI("_tmp")
 	require.NoError(t, err)
 
 	s := strelets.NewStrelets("_tmp", api)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/orbs-network/boyarin/test"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"os"
 	"testing"
 	"time"
 )
@@ -32,9 +31,7 @@ func TestE2E(t *testing.T) {
 }
 
 func TestE2EWithDocker(t *testing.T) {
-	if os.Getenv("ENABLE_DOCKER") != "true" {
-		t.Skip("skipping test, docker is disabled")
-	}
+	skipUnlessDockerIsEnabled(t)
 
 	realDocker, err := adapter.NewDockerAPI("_tmp")
 	require.NoError(t, err)
@@ -47,9 +44,7 @@ func TestE2EWithDocker(t *testing.T) {
 }
 
 func TestE2EWithDockerAndBoyar(t *testing.T) {
-	if os.Getenv("ENABLE_DOCKER") != "true" {
-		t.Skip("skipping test, docker is disabled")
-	}
+	skipUnlessDockerIsEnabled(t)
 
 	realDocker, err := adapter.NewDockerAPI("_tmp")
 	require.NoError(t, err)
@@ -102,9 +97,7 @@ func TestE2EWithDockerAndBoyar(t *testing.T) {
 }
 
 func TestE2EWithDockerSwarm(t *testing.T) {
-	if os.Getenv("ENABLE_SWARM") != "true" {
-		t.Skip("skipping test, docker swarm is disabled")
-	}
+	skipUnlessSwarmIsEnabled(t)
 
 	realDocker, err := adapter.NewDockerSwarm()
 	require.NoError(t, err)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -36,7 +36,7 @@ func TestE2EWithDocker(t *testing.T) {
 		t.Skip("skipping test, docker is disabled")
 	}
 
-	realDocker, err := adapter.NewDockerAPI()
+	realDocker, err := adapter.NewDockerAPI("_tmp")
 	require.NoError(t, err)
 	h := newHarness(t, realDocker)
 
@@ -51,7 +51,7 @@ func TestE2EWithDockerAndBoyar(t *testing.T) {
 		t.Skip("skipping test, docker is disabled")
 	}
 
-	realDocker, err := adapter.NewDockerAPI()
+	realDocker, err := adapter.NewDockerAPI("_tmp")
 	require.NoError(t, err)
 	h := newHarness(t, realDocker)
 

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -35,18 +35,22 @@ func newHarness(t *testing.T, docker adapter.Orchestrator) *harness {
 	}
 }
 
+func chain(i int) *strelets.VirtualChain {
+	return &strelets.VirtualChain{
+		Id:           42,
+		HttpPort:     8080 + i,
+		GossipPort:   4400 + i,
+		DockerConfig: DockerConfig(fmt.Sprintf("node%d", i)),
+	}
+}
+
 func (h *harness) startChain(t *testing.T) {
 	localIP := test.LocalIP()
 	ctx := context.Background()
 
 	for i := 1; i <= 3; i++ {
 		err := h.s.ProvisionVirtualChain(ctx, &strelets.ProvisionVirtualChainInput{
-			VirtualChain: &strelets.VirtualChain{
-				Id:           42,
-				HttpPort:     8080 + i,
-				GossipPort:   4400 + i,
-				DockerConfig: DockerConfig(fmt.Sprintf("node%d", i)),
-			},
+			VirtualChain:      chain(i),
 			Peers:             Peers(localIP),
 			KeyPairConfigPath: fmt.Sprintf("%s/node%d/keys.json", h.configPath, i),
 		})

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -144,3 +144,15 @@ func waitForBlock(t *testing.T, getMetrics func() (map[string]interface{}, error
 		return blockHeight >= targetBlockHeight
 	}))
 }
+
+func skipUnlessDockerIsEnabled(t *testing.T) {
+	if os.Getenv("ENABLE_DOCKER") != "true" {
+		t.Skip("skipping test, docker is disabled")
+	}
+}
+
+func skipUnlessSwarmIsEnabled(t *testing.T) {
+	if os.Getenv("ENABLE_SWARM") != "true" {
+		t.Skip("skipping test, docker swarm is disabled")
+	}
+}

--- a/test/e2e/orchestrator_adapter.go
+++ b/test/e2e/orchestrator_adapter.go
@@ -50,7 +50,7 @@ func (r *MockRunner) Run(ctx context.Context) error {
 	return nil
 }
 
-func (d *MockOrchestratorAdapter) UpdateReverseProxy(ctx context.Context, config string) error {
+func (d *MockOrchestratorAdapter) PrepareReverseProxy(ctx context.Context, config string) (adapter.Runner, error) {
 	panic("not implemented")
-	return nil
+	return nil, nil
 }

--- a/test/e2e/orchestrator_adapter.go
+++ b/test/e2e/orchestrator_adapter.go
@@ -30,7 +30,7 @@ func (d *MockOrchestratorAdapter) PullImage(ctx context.Context, imageName strin
 	return nil
 }
 
-func (d *MockOrchestratorAdapter) Prepare(ctx context.Context, imageName string, containerName string, root string, httpPort int, gossipPort int, config *adapter.AppConfig) (adapter.Runner, error) {
+func (d *MockOrchestratorAdapter) Prepare(ctx context.Context, imageName string, containerName string, httpPort int, gossipPort int, config *adapter.AppConfig) (adapter.Runner, error) {
 	d.mock.MethodCalled("Prepare", ctx, containerName, config)
 	return d.runner, nil
 }

--- a/test/e2e/orchestrator_adapter.go
+++ b/test/e2e/orchestrator_adapter.go
@@ -49,3 +49,8 @@ func (r *MockRunner) Run(ctx context.Context) error {
 	r.mock.MethodCalled("Run", ctx)
 	return nil
 }
+
+func (d *MockOrchestratorAdapter) UpdateReverseProxy(ctx context.Context, config string) error {
+	panic("not implemented")
+	return nil
+}

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -56,6 +56,7 @@ type HttpServer interface {
 	Start()
 	Shutdown()
 	Url() string
+	Port() int
 }
 
 type httpServer struct {
@@ -76,8 +77,12 @@ func (h *httpServer) Url() string {
 	return fmt.Sprintf("http://127.0.0.1:%d%s", h.listener.Addr().(*net.TCPAddr).Port, h.path)
 }
 
+func (h *httpServer) Port() int {
+	return h.listener.Addr().(*net.TCPAddr).Port
+}
+
 func CreateHttpServer(path string, f func(writer http.ResponseWriter, request *http.Request)) HttpServer {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listener, err := net.Listen("tcp", "0.0.0.0:0")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Vchain endpoints are proxied via `/vchains/{vcid}/` endpoint, meaning `/api/v1/send-transaction` becomes `/vchain/{vcid}/api/v1/send-transaction` 