### PR TITLE
Update vchains

### DIFF
--- a/strelets/adapter/swarm_prepare_reverse_proxy.go
+++ b/strelets/adapter/swarm_prepare_reverse_proxy.go
@@ -7,14 +7,15 @@ import (
 )
 
 func (d *dockerSwarm) PrepareReverseProxy(ctx context.Context, config string) (Runner, error) {
-	storedSecrets, err := d.storeNginxConfiguration(ctx, config)
-	if err != nil {
-		return nil, err
-	}
-
 	return &dockerSwarmRunner{
 		client: d.client,
-		spec:   getNginxServiceSpec(storedSecrets),
+		spec: func() (swarm.ServiceSpec, error) {
+			storedSecrets, err := d.storeNginxConfiguration(ctx, config)
+			if err != nil {
+				return swarm.ServiceSpec{}, err
+			}
+			return getNginxServiceSpec(storedSecrets), nil
+		},
 	}, nil
 }
 

--- a/test/e2e/e2e_boyar_test.go
+++ b/test/e2e/e2e_boyar_test.go
@@ -1,0 +1,77 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/orbs-network/boyarin/boyar"
+	"github.com/orbs-network/boyarin/strelets"
+	"github.com/orbs-network/boyarin/strelets/adapter"
+	"github.com/orbs-network/boyarin/test"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func getBoyarConfig(httpPort int, gossipPort int, nodeIndex int, vchainIds ...int) []byte {
+	ip := test.LocalIP()
+
+	configMap := make(map[string]interface{})
+	var network []*strelets.FederationNode
+	for i, key := range test.PublicKeys() {
+		network = append(network, &strelets.FederationNode{
+			Key:  key,
+			IP:   ip,
+			Port: gossipPort + i + 1,
+		})
+	}
+
+	configMap["network"] = network
+
+	var chains []*strelets.VirtualChain
+
+	for _, vchainId := range vchainIds {
+		chain := &strelets.VirtualChain{
+			Id:         strelets.VirtualChainId(vchainId),
+			HttpPort:   httpPort + nodeIndex,
+			GossipPort: gossipPort + nodeIndex,
+			DockerConfig: &strelets.DockerImageConfig{
+				ContainerNamePrefix: fmt.Sprintf("node%d", nodeIndex),
+				Image:               "orbs",
+				Tag:                 "export",
+				Pull:                false,
+			},
+		}
+
+		chains = append(chains, chain)
+	}
+
+	configMap["chains"] = chains
+
+	jsonConfig, _ := json.Marshal(configMap)
+	return jsonConfig
+}
+
+func TestE2EWithDockerAndBoyar(t *testing.T) {
+	skipUnlessDockerIsEnabled(t)
+
+	realDocker, err := adapter.NewDockerAPI("_tmp")
+	require.NoError(t, err)
+	h := newHarness(t, realDocker)
+
+	s := strelets.NewStrelets("_tmp", realDocker)
+
+	for i := 1; i <= 3; i++ {
+		boyarConfig := getBoyarConfig(8080, 4400, i, 42)
+		config, err := boyar.NewStringConfigurationSource(string(boyarConfig))
+		require.NoError(t, err)
+
+		b := boyar.NewBoyar(s, config, fmt.Sprintf("%s/node%d/keys.json", h.configPath, i))
+		err = b.ProvisionVirtualChains(context.Background())
+		require.NoError(t, err)
+	}
+	// FIXME boyar should take care of it, not the harness
+	defer h.stopChain(t)
+
+	waitForBlock(t, h.getMetricsForPort(8083), 3, 20*time.Second)
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,13 +1,8 @@
 package e2e
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"github.com/orbs-network/boyarin/boyar"
-	"github.com/orbs-network/boyarin/strelets"
 	"github.com/orbs-network/boyarin/strelets/adapter"
-	"github.com/orbs-network/boyarin/test"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -41,59 +36,6 @@ func TestE2EWithDocker(t *testing.T) {
 	defer h.stopChain(t)
 
 	waitForBlock(t, h.getMetrics, 3, 15*time.Second)
-}
-
-func TestE2EWithDockerAndBoyar(t *testing.T) {
-	skipUnlessDockerIsEnabled(t)
-
-	realDocker, err := adapter.NewDockerAPI("_tmp")
-	require.NoError(t, err)
-	h := newHarness(t, realDocker)
-
-	s := strelets.NewStrelets("_tmp", realDocker)
-
-	configMap := make(map[string]interface{})
-
-	ip := test.LocalIP()
-
-	var network []*strelets.FederationNode
-	for i, key := range test.PublicKeys() {
-		network = append(network, &strelets.FederationNode{
-			Key:  key,
-			IP:   ip,
-			Port: 4400 + i + 1,
-		})
-	}
-
-	configMap["network"] = network
-
-	for i := 1; i <= 3; i++ {
-		chain := &strelets.VirtualChain{
-			Id:         42,
-			HttpPort:   8080 + i,
-			GossipPort: 4400 + i,
-			DockerConfig: &strelets.DockerImageConfig{
-				ContainerNamePrefix: fmt.Sprintf("node%d", i),
-				Image:               "orbs",
-				Tag:                 "export",
-				Pull:                false,
-			},
-		}
-
-		configMap["chains"] = []*strelets.VirtualChain{chain}
-
-		jsonConfig, _ := json.Marshal(configMap)
-		config, err := boyar.NewStringConfigurationSource(string(jsonConfig))
-		require.NoError(t, err)
-
-		b := boyar.NewBoyar(s, config, fmt.Sprintf("%s/node%d/keys.json", h.configPath, i))
-		err = b.ProvisionVirtualChains(context.Background())
-		require.NoError(t, err)
-	}
-	// FIXME boyar should take care of it, not the harness
-	defer h.stopChain(t)
-
-	waitForBlock(t, h.getMetrics, 3, 20*time.Second)
 }
 
 func TestE2EWithDockerSwarm(t *testing.T) {

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -106,9 +106,9 @@ func (h *harness) getMetrics() (map[string]interface{}, error) {
 	return h.getMetricsForPort(8081)()
 }
 
-func (h *harness) getMetricsForPort(httpPort int) func() (map[string]interface{}, error) {
+func (h *harness) getMetricsForEndpoint(getEndpoint func() string) func() (map[string]interface{}, error) {
 	return func() (map[string]interface{}, error) {
-		data, err := h.httpGet(h.getMetricsEndpoint(httpPort))
+		data, err := h.httpGet(getEndpoint())
 		if err != nil {
 			return nil, err
 		}
@@ -120,6 +120,18 @@ func (h *harness) getMetricsForPort(httpPort int) func() (map[string]interface{}
 
 		return metrics, nil
 	}
+}
+
+func (h *harness) getMetricsForVchain(port int, vchainId int) func() (map[string]interface{}, error) {
+	return h.getMetricsForEndpoint(func() string {
+		return "http://" + test.LocalIP() + ":" + strconv.Itoa(port) + "/vchains/" + strconv.Itoa(vchainId) + "/metrics"
+	})
+}
+
+func (h *harness) getMetricsForPort(httpPort int) func() (map[string]interface{}, error) {
+	return h.getMetricsForEndpoint(func() string {
+		return h.getMetricsEndpoint(httpPort)
+	})
 }
 
 func DockerConfig(node string) *strelets.DockerImageConfig {


### PR DESCRIPTION
Currently just removes vchains and recreates them, meaning we can run boyar on the same cluster multiple times in a row.