### PR TITLE
Healthcheck for services

### DIFF
--- a/boyar/nginx_config_test.go
+++ b/boyar/nginx_config_test.go
@@ -21,6 +21,12 @@ location ~ ^/vchains/42(/?)(.*) {
 	proxy_pass http://$vc42:8080/$2;
 	error_page 502 = @error502;
 }
+location /services/signer-service/status {
+	alias /opt/orbs/status/signer-service/status.json;
+}
+location /services/management-service/status {
+	alias /opt/orbs/status/management-service/status.json;
+}
 }`,
 		getNginxConfig(cfg))
 }
@@ -45,6 +51,12 @@ location ~ ^/vchains/1991(/?)(.*) {
 	proxy_pass http://$vc1991:8080/$2;
 	error_page 502 = @error502;
 }
+location /services/signer-service/status {
+	alias /opt/orbs/status/signer-service/status.json;
+}
+location /services/management-service/status {
+	alias /opt/orbs/status/management-service/status.json;
+}
 }`,
 		getNginxConfig(cfg))
 }
@@ -67,6 +79,12 @@ location ~ ^/vchains/42(/?)(.*) {
 	proxy_pass http://$vc42:8080/$2;
 	error_page 502 = @error502;
 }
+location /services/signer-service/status {
+	alias /opt/orbs/status/signer-service/status.json;
+}
+location /services/management-service/status {
+	alias /opt/orbs/status/management-service/status.json;
+}
 }
 server {
 resolver 127.0.0.11 ipv6=off;
@@ -82,6 +100,12 @@ set $vc42 cfc9e5-chain-42-stack;
 location ~ ^/vchains/42(/?)(.*) {
 	proxy_pass http://$vc42:8080/$2;
 	error_page 502 = @error502;
+}
+location /services/signer-service/status {
+	alias /opt/orbs/status/signer-service/status.json;
+}
+location /services/management-service/status {
+	alias /opt/orbs/status/management-service/status.json;
 }
 }`,
 		getNginxConfig(cfg))

--- a/boyar/provision_http_api_endpoint.go
+++ b/boyar/provision_http_api_endpoint.go
@@ -24,6 +24,7 @@ func (b *boyar) ProvisionHttpAPIEndpoint(ctx context.Context) error {
 			NginxConfig:   getNginxConfig(b.config),
 			HTTPPort:      b.config.OrchestratorOptions().HTTPPort,
 			SSLPort:       b.config.OrchestratorOptions().SSLPort,
+			Services:      getReverseProxyServices(b.config),
 		}
 
 		if sslEnabled {
@@ -64,4 +65,15 @@ func getNginxCompositeConfig(cfg config.NodeConfiguration) *UpdateReverseProxyIn
 		IP:         helpers.LocalIP(),
 		SSLOptions: cfg.SSLOptions(),
 	}
+}
+
+func getReverseProxyServices(cfg config.NodeConfiguration) (services []adapter.ReverseProxyConfigService) {
+	for serviceConfig, _ := range cfg.Services().AsMap() {
+		services = append(services, adapter.ReverseProxyConfigService{
+			Name:        serviceConfig.Name,
+			ServiceName: cfg.PrefixedContainerName(serviceConfig.Name),
+		})
+	}
+
+	return
 }

--- a/strelets/adapter/orchestrator.go
+++ b/strelets/adapter/orchestrator.go
@@ -18,8 +18,11 @@ type AppConfig struct {
 }
 
 type ServiceConfig struct {
-	Id            uint32
-	NodeAddress   string
+	// vchain only
+	Id          uint32
+	NodeAddress string
+
+	// common
 	ImageName     string
 	ContainerName string
 	Executable    string

--- a/strelets/adapter/swarm_prepare.go
+++ b/strelets/adapter/swarm_prepare.go
@@ -45,7 +45,7 @@ func (d *dockerSwarmOrchestrator) RunVirtualChain(ctx context.Context, serviceCo
 		getSecretReference(serviceConfig.ContainerName, config.networkSecretId, "network", "network.json"),
 	}
 
-	mounts, err := d.provisionVolumes(ctx, serviceConfig.NodeAddress, serviceConfig.Id,
+	mounts, err := d.provisionVchainVolumes(ctx, serviceConfig.NodeAddress, serviceConfig.Id,
 		defaultValue(serviceConfig.BlocksVolumeSize, 100), defaultValue(serviceConfig.LogsVolumeSize, 2))
 	if err != nil {
 		return fmt.Errorf("failed to provision volumes: %s", err)

--- a/strelets/adapter/swarm_prepare_reverse_proxy_test.go
+++ b/strelets/adapter/swarm_prepare_reverse_proxy_test.go
@@ -19,7 +19,7 @@ func Test_getNginxServiceSpec(t *testing.T) {
 		vchainConfId: "vchain-config-id",
 		nginxConfId:  "nginx-config-id",
 	}
-	spec := getNginxServiceSpec(namespace, httpPort, sslPort, secrets, nil)
+	spec := getNginxServiceSpec(namespace, httpPort, sslPort, secrets, nil, nil)
 
 	require.EqualValues(t, "node123-proxy-stack", spec.Name)
 

--- a/strelets/adapter/swarm_prepare_service.go
+++ b/strelets/adapter/swarm_prepare_service.go
@@ -9,9 +9,7 @@ import (
 )
 
 func (d *dockerSwarmOrchestrator) RunService(ctx context.Context, serviceConfig *ServiceConfig, appConfig *AppConfig) error {
-	serviceName := GetServiceId(serviceConfig.ContainerName)
-
-	if err := d.RemoveService(ctx, serviceName); err != nil {
+	if err := d.RemoveService(ctx, GetServiceId(serviceConfig.ContainerName)); err != nil {
 		return err
 	}
 
@@ -37,7 +35,7 @@ func (d *dockerSwarmOrchestrator) RunService(ctx context.Context, serviceConfig 
 		secrets = append(secrets, getSecretReference(serviceConfig.ContainerName, config.keysSecretId, "keyPair", "keys.json"))
 	}
 
-	mounts, err := d.provisionServiceVolumes(ctx, serviceName)
+	mounts, err := d.provisionServiceVolumes(ctx, serviceConfig.ContainerName, ORBS_STATUS_TARGET)
 	if err != nil {
 		return err
 	}

--- a/strelets/adapter/swarm_prepare_service_test.go
+++ b/strelets/adapter/swarm_prepare_service_test.go
@@ -1,6 +1,7 @@
 package adapter
 
 import (
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -26,7 +27,11 @@ func Test_getServiceSpec(t *testing.T) {
 		{Target: "signer"},
 	}
 
-	spec := getServiceSpec(serviceConfig, secrets, networkConfig)
+	mounts := []mount.Mount{
+		{Source: "/tmp/a", Target: "/tmp/b"},
+	}
+
+	spec := getServiceSpec(serviceConfig, secrets, networkConfig, mounts)
 
 	require.EqualValues(t, spec.Name, containerName+"-stack")
 
@@ -39,6 +44,7 @@ func Test_getServiceSpec(t *testing.T) {
 			},
 			Secrets: secrets,
 			Sysctls: GetSysctls(),
+			Mounts:  mounts,
 		},
 		RestartPolicy: &swarm.RestartPolicy{
 			Condition: "",

--- a/strelets/adapter/swarm_volumes.go
+++ b/strelets/adapter/swarm_volumes.go
@@ -12,25 +12,44 @@ import (
 
 const ORBS_BLOCKS_TARGET = "/usr/local/var/orbs"
 const ORBS_LOGS_TARGET = "/opt/orbs/logs"
+const ORBS_STATUS_TARGET = "/opt/orbs/status"
+const NO_VCHAIN_ID = 0
 
 const REXRAY_EBS_DRIVER = "rexray/ebs"
 const LOCAL_DRIVER = "local"
 
-func getVolumeName(nodeAddress string, id uint32, postfix string) string {
-	return fmt.Sprintf("%s-%d-%s", nodeAddress, id, postfix)
+func getVolumeName(nodeAddress string, virtualChainId uint32, postfix string) string {
+	return fmt.Sprintf("%s-%d-%s", nodeAddress, virtualChainId, postfix)
 }
 
-func (d *dockerSwarmOrchestrator) provisionVolumes(ctx context.Context, nodeAddress string, id uint32, blocksVolumeSize int, logsVolumeSize int) (mounts []mount.Mount, err error) {
-	if logsMount, err := d.provisionVolume(ctx, getVolumeName(nodeAddress, id, "logs"), ORBS_LOGS_TARGET, logsVolumeSize, OrchestratorOptions{}); err != nil {
+func (d *dockerSwarmOrchestrator) provisionVchainVolumes(ctx context.Context, nodeAddress string, virtualChainId uint32, blocksVolumeSize int, logsVolumeSize int) (mounts []mount.Mount, err error) {
+	if logsMount, err := d.provisionVolume(ctx, getVolumeName(nodeAddress, virtualChainId, "logs"), ORBS_LOGS_TARGET, logsVolumeSize, OrchestratorOptions{}); err != nil {
 		return mounts, err
 	} else {
 		mounts = append(mounts, logsMount)
 	}
 
-	if blocksMount, err := d.provisionVolume(ctx, getVolumeName(nodeAddress, id, "blocks"), ORBS_BLOCKS_TARGET, blocksVolumeSize, d.options); err != nil {
+	if blocksMount, err := d.provisionVolume(ctx, getVolumeName(nodeAddress, virtualChainId, "blocks"), ORBS_BLOCKS_TARGET, blocksVolumeSize, d.options); err != nil {
 		return mounts, err
 	} else {
 		mounts = append(mounts, blocksMount)
+	}
+
+	return mounts, nil
+}
+
+func getStatusVolumeName(serviceName string) string {
+	return serviceName + "-status"
+}
+
+func (d *dockerSwarmOrchestrator) provisionServiceVolumes(ctx context.Context, serviceName string) (mounts []mount.Mount, err error) {
+	if statusMount, err := d.provisionVolume(ctx, getStatusVolumeName(serviceName), ORBS_STATUS_TARGET, 0, OrchestratorOptions{
+		// FIXME should be enabled in production
+		//StorageMountType: "bind",
+	}); err != nil {
+		return mounts, err
+	} else {
+		mounts = append(mounts, statusMount)
 	}
 
 	return mounts, nil

--- a/strelets/adapter/swarm_volumes.go
+++ b/strelets/adapter/swarm_volumes.go
@@ -13,7 +13,6 @@ import (
 const ORBS_BLOCKS_TARGET = "/usr/local/var/orbs"
 const ORBS_LOGS_TARGET = "/opt/orbs/logs"
 const ORBS_STATUS_TARGET = "/opt/orbs/status"
-const NO_VCHAIN_ID = 0
 
 const REXRAY_EBS_DRIVER = "rexray/ebs"
 const LOCAL_DRIVER = "local"
@@ -42,11 +41,8 @@ func getStatusVolumeName(serviceName string) string {
 	return serviceName + "-status"
 }
 
-func (d *dockerSwarmOrchestrator) provisionServiceVolumes(ctx context.Context, serviceName string) (mounts []mount.Mount, err error) {
-	if statusMount, err := d.provisionVolume(ctx, getStatusVolumeName(serviceName), ORBS_STATUS_TARGET, 0, OrchestratorOptions{
-		// FIXME should be enabled in production
-		//StorageMountType: "bind",
-	}); err != nil {
+func (d *dockerSwarmOrchestrator) provisionServiceVolumes(ctx context.Context, serviceName string, mountTarget string) (mounts []mount.Mount, err error) {
+	if statusMount, err := d.provisionVolume(ctx, getStatusVolumeName(serviceName), mountTarget, 0, d.options); err != nil {
 		return mounts, err
 	} else {
 		mounts = append(mounts, statusMount)

--- a/test/e2e/e2e_network_test.go
+++ b/test/e2e/e2e_network_test.go
@@ -82,7 +82,7 @@ func TestE2ERunFullNetwork(t *testing.T) {
 
 				waiter = InProcessBoyar(t, ctx, logger, flags)
 
-				helpers.RequireEventually(t, 30*time.Second, func(t helpers.TestingT) {
+				helpers.RequireEventually(t, 1*time.Minute, func(t helpers.TestingT) {
 					AssertVchainUp(t, httpPort, keys.NodeAddress, vc)
 				})
 
@@ -91,7 +91,7 @@ func TestE2ERunFullNetwork(t *testing.T) {
 		}(i, keys)
 	}
 
-	helpers.RequireEventually(t, 2*time.Minute, func(t helpers.TestingT) {
+	helpers.RequireEventually(t, 3*time.Minute, func(t helpers.TestingT) {
 		metrics := GetVChainMetrics(t, basePort*2, vcs[0])
 		require.EqualValues(t, 3, metrics.Uint64("BlockStorage.BlockHeight"))
 	})


### PR DESCRIPTION
Works with node services, can be expanded to work with ONG as well.

Builds on top of https://github.com/orbs-network/orbs-network-go/pull/1542

Missing: e2e.

@talkol at this point, EBS will not work on multi-machine configurations, so I either have to drop the support, or we should be mindful that this version should not go to production until we move to EFS completely.